### PR TITLE
[codex] Add Settings Hub social links

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,12 @@ This project uses the **OWASP Mobile Application Security Verification Standard 
 
 ## 🔗 Useful Links
 
-**Project repo**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-->&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**[GitHub.com](https://github.com/DvilSpawn/Re-TUI)**<br>
+**Project repo**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-->&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**[GitHub.com](https://github.com/DvilSpawn/Re-TUI.git)**<br>
 **Project wiki**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-->&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**[GitHub Wiki](https://github.com/DvilSpawn/Re-TUI/wiki)**<br>
 **Wiki in repo**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-->&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**[docs/wiki/Home.md](./docs/wiki/Home.md)**<br>
 **Community**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-->&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**[Reddit](https://www.reddit.com/r/RE_TUI_launcher/)**<br>
-**Chat**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-->&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**[Discord](https://discord.gg/zNtUwa7e)**<br>
+**Chat**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-->&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**[Discord](https://discord.gg/n6zsVYuV)**<br>
+**Email**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-->&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**[DvilSpawn@gmail.com](mailto:DvilSpawn@gmail.com)**<br>
 
 ## 📚 Open Source Libraries
 * [**CompareString2**](https://github.com/fAndreuzzi/CompareString2)

--- a/app/src/main/java/ohi/andre/consolelauncher/commands/tuixt/ThemerActivity.kt
+++ b/app/src/main/java/ohi/andre/consolelauncher/commands/tuixt/ThemerActivity.kt
@@ -201,6 +201,12 @@ class ThemerActivity : AppCompatActivity() {
                         launchRestorePicker()
                     } else if (fileName == "Rate the App") {
                         openPlayStoreListing()
+                    } else if (fileName == "GitHub") {
+                        openExternalUrl(GITHUB_URL)
+                    } else if (fileName == "Discord") {
+                        openExternalUrl(DISCORD_URL)
+                    } else if (fileName == "Reddit") {
+                        openExternalUrl(REDDIT_URL)
                     } else if (fileName == "Send Feedback") {
                         openFeedbackEmail()
                     } else if (fileName == "Learn More") {
@@ -261,7 +267,15 @@ class ThemerActivity : AppCompatActivity() {
     }
 
     private fun openLearnMore() {
-        startActivity(Tuils.webPage(LEARN_MORE_URL))
+        openExternalUrl(LEARN_MORE_URL)
+    }
+
+    private fun openExternalUrl(url: String) {
+        try {
+            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+        } catch (e: ActivityNotFoundException) {
+            Toast.makeText(this, "No browser app found.", Toast.LENGTH_SHORT).show()
+        }
     }
 
     private fun showPresetsDialog() {
@@ -378,6 +392,9 @@ class ThemerActivity : AppCompatActivity() {
                 "Backup",
                 "Create Shareable Configuration",
                 "Restore",
+                "GitHub",
+                "Discord",
+                "Reddit",
                 "Rate the App",
                 "Send Feedback",
                 "Learn More",
@@ -1330,7 +1347,10 @@ class ThemerActivity : AppCompatActivity() {
         private const val PLAY_STORE_MARKET_URL = "market://details?id=$PLAY_STORE_PACKAGE_ID"
         private const val PLAY_STORE_WEB_URL =
             "https://play.google.com/store/apps/details?id=$PLAY_STORE_PACKAGE_ID"
-        private const val FEEDBACK_EMAIL = "dvilspawn@gmail.com"
+        private const val GITHUB_URL = "https://github.com/DvilSpawn/Re-TUI.git"
+        private const val DISCORD_URL = "https://discord.gg/n6zsVYuV"
+        private const val REDDIT_URL = "https://www.reddit.com/r/RE_TUI_launcher/"
+        private const val FEEDBACK_EMAIL = "DvilSpawn@gmail.com"
         private const val FEEDBACK_MAILTO_URI = "mailto:$FEEDBACK_EMAIL"
         private const val GMAIL_PACKAGE = "com.google.android.gm"
         private const val LEARN_MORE_URL = "https://re-tui.pages.dev"

--- a/docs/ascii.html
+++ b/docs/ascii.html
@@ -380,7 +380,7 @@
           <div class="tree-group">
             <p class="tree-dir">release</p>
             <a class="external" href="privacy.html">privacy.html</a>
-            <a class="external" href="https://github.com/DvilSpawn/Re-TUI">source.git</a>
+            <a class="external" href="https://github.com/DvilSpawn/Re-TUI.git">source.git</a>
           </div>
         </nav>
       </aside>

--- a/docs/index.html
+++ b/docs/index.html
@@ -57,7 +57,7 @@
             <a class="external" href="https://play.google.com/store/apps/details?id=com.dvil.tui_renewed">play-store.url</a>
             <a class="external" href="https://github.com/DvilSpawn/Re-TUI/releases/latest/download/app-github-release.apk">github-apk.url</a>
             <a class="external" href="privacy.html">privacy.html</a>
-            <a class="external" href="https://github.com/DvilSpawn/Re-TUI">source.git</a>
+            <a class="external" href="https://github.com/DvilSpawn/Re-TUI.git">source.git</a>
           </div>
         </nav>
       </aside>
@@ -81,7 +81,7 @@
                 <a class="terminal-link primary" href="#wiki-map">open wiki.map</a>
                 <a class="terminal-link" href="#product-showcase">less screenshots.log</a>
                 <a class="terminal-link" href="#downloads">cat downloads.env</a>
-                <a class="terminal-link" href="https://github.com/DvilSpawn/Re-TUI">git remote</a>
+                <a class="terminal-link" href="https://github.com/DvilSpawn/Re-TUI.git">git remote</a>
               </div>
             </div>
           </section>
@@ -315,6 +315,10 @@
               <h2>Open development, practical reports.</h2>
               <p>Useful feedback includes the command used, visible output, Android version, build channel, and whether the issue affects Play Store, GitHub, or a local debug install.</p>
               <ul class="terminal-list">
+                <li><strong>Source:</strong> <a href="https://github.com/DvilSpawn/Re-TUI.git">GitHub repository</a> for code and releases.</li>
+                <li><strong>Chat:</strong> <a href="https://discord.gg/n6zsVYuV">Discord server</a> for community discussion.</li>
+                <li><strong>Community:</strong> <a href="https://www.reddit.com/r/RE_TUI_launcher/">Reddit</a> for launcher posts and shared setups.</li>
+                <li><strong>Email:</strong> <a href="mailto:DvilSpawn@gmail.com">DvilSpawn@gmail.com</a> for direct feedback.</li>
                 <li><strong>Issues:</strong> <a href="https://github.com/DvilSpawn/Re-TUI/issues">GitHub issues</a> for reproducible bugs.</li>
                 <li><strong>Privacy:</strong> <a href="privacy.html">Permission and data behavior</a> for app review and user trust.</li>
                 <li><strong>Files:</strong> Re:T-UI Files owns file navigation; the launcher remains the command desk.</li>

--- a/docs/moderate.html
+++ b/docs/moderate.html
@@ -266,7 +266,7 @@
           <div class="tree-group">
             <p class="tree-dir">release</p>
             <a class="external" href="privacy.html">privacy.html</a>
-            <a class="external" href="https://github.com/DvilSpawn/Re-TUI">source.git</a>
+            <a class="external" href="https://github.com/DvilSpawn/Re-TUI.git">source.git</a>
           </div>
         </nav>
       </aside>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -43,7 +43,7 @@
             <p class="tree-dir">support</p>
             <a class="external" href="index.html#support-release-channels">support.channels</a>
             <a class="external" href="viewer.html?file=wiki/FAQ-and-Troubleshooting.md">FAQ.md</a>
-            <a class="external" href="https://github.com/DvilSpawn/Re-TUI">source.git</a>
+            <a class="external" href="https://github.com/DvilSpawn/Re-TUI.git">source.git</a>
           </div>
         </nav>
       </aside>
@@ -148,10 +148,11 @@
               <div class="kicker">Children, Changes, Contact</div>
               <p>Re:T-UI is a customization and productivity launcher. It is not directed to children. If you believe a child has provided personal information through the app, contact the developer so the issue can be reviewed.</p>
               <p>This policy may be updated when Re:T-UI adds or changes features, permissions, diagnostics, or distribution channels. The effective date at the top of this page will be updated when material changes are made.</p>
-              <p>For privacy questions, open an issue on the project page or contact the developer through the current support channel linked from Re:T-UI.</p>
+              <p>For privacy questions, open an issue on the project page, use the current support channels linked from Re:T-UI, or email the developer directly.</p>
               <div class="terminal-links">
-                <a class="terminal-link primary" href="https://github.com/DvilSpawn/Re-TUI">git remote get-url origin</a>
+                <a class="terminal-link primary" href="https://github.com/DvilSpawn/Re-TUI.git">git remote get-url origin</a>
                 <a class="terminal-link" href="index.html#support-release-channels">open support.channels</a>
+                <a class="terminal-link" href="mailto:DvilSpawn@gmail.com">mail DvilSpawn@gmail.com</a>
               </div>
             </div>
           </section>


### PR DESCRIPTION
## Summary

Stacks on the cleanup guardrails PR and adds canonical social/support links to Settings Hub.

- Adds `GitHub`, `Discord`, and `Reddit` rows to `System & Support`.
- Keeps `Rate the App`, `Send Feedback`, `Learn More`, `View Crash Log`, backup, shareable configuration, and restore actions.
- Uses a shared external URL opener for the new links and Learn More.
- Updates feedback email to `DvilSpawn@gmail.com` with existing `mailto:` behavior.
- Aligns README/docs support links with the canonical values.

## Stack

Depends on cleanup guardrails PR: https://github.com/DvilSpawn/Re-TUI/pull/5

## Validation

- `./gradlew :app:assemblePlaystoreDebug`
- `./gradlew :app:assembleFdroidDebug`
- `./gradlew :app:lintPlaystoreDebug`
- Phone smoke on `10BE1C0FB40006A`: installed `app-playstore-debug.apk`, opened `settings`, verified `System & Support` renders GitHub/Discord/Reddit/Send Feedback plus existing support rows.
- GitHub row opened the native GitHub app to `DvilSpawn/Re-TUI`; Discord, Reddit, and email resolve through Android intent resolver.